### PR TITLE
Removing reference to hardcoded 'key' index name.

### DIFF
--- a/src/Sitecore.Support.149252/SolrStartup.cs
+++ b/src/Sitecore.Support.149252/SolrStartup.cs
@@ -3,19 +3,15 @@ using Sitecore.ContentSearch.SolrProvider;
 using Sitecore.ContentSearch.SolrProvider.DocumentSerializers;
 using Sitecore.ContentSearch.SolrProvider.Parsers;
 using Sitecore.ContentSearch.SolrProvider.SolrNetIntegration;
-using Sitecore.Reflection;
 using SolrNet;
 using SolrNet.Impl;
 using SolrNet.Mapping.Validation;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Web;
 
 namespace Sitecore.Support.ContentSearch.SolrProvider.SolrNetIntegration
 {
-    public class SolrStartup: DefaultSolrStartUp
+    public class SolrStartup : DefaultSolrStartUp
     {
         public override void Initialize()
         {
@@ -32,7 +28,7 @@ namespace Sitecore.Support.ContentSearch.SolrProvider.SolrNetIntegration
             }
             if (SolrContentSearchManager.EnableHttpCache)
             {
-                ISolrCache cache = ReflectionUtil.GetField(this, typeof(DefaultSolrStartUp) , "solrCache") as ISolrCache;                
+                ISolrCache cache = ReflectionUtil.GetField(this, typeof(DefaultSolrStartUp), "solrCache") as ISolrCache;
                 this.Operations.HttpCache = cache;
             }
             this.Operations.CoreAdmin = this.BuildCoreAdmin();
@@ -41,25 +37,26 @@ namespace Sitecore.Support.ContentSearch.SolrProvider.SolrNetIntegration
             this.ReplaceSolrOperations();
             SolrContentSearchManager.Initialize();
         }
-       
+
 
         public void ReplaceSolrOperations()
         {
-            string key = "sitecore_master_index";
-
             IServiceLocator test2 = ServiceLocator.Current;
             DefaultSolrLocator<Dictionary<string, object>> OpPr = Sitecore.Reflection.ReflectionUtil.GetProperty(test2, "Operations") as DefaultSolrLocator<Dictionary<string, object>>;
             Dictionary<string, Dictionary<string, object>> KeyPr = Sitecore.Reflection.ReflectionUtil.GetProperty(OpPr, "KeyedServiceCollection") as Dictionary<string, Dictionary<string, object>>;
-            Dictionary<string, object> objects = KeyPr[key];
-            string typeKey = typeof(ISolrOperations<Dictionary<string, object>>).Name;
-            objects.Remove(typeKey);
 
+            foreach (string key in KeyPr.Keys)
+            {
+                Dictionary<string, object> objects = KeyPr[key];
+                string typeKey = typeof(ISolrOperations<Dictionary<string, object>>).Name;
+                objects.Remove(typeKey);
 
-            var operations = ServiceLocator.Current.GetInstance<ISolrBasicOperations<Dictionary<string, object>>>(key);
-            var validator = ServiceLocator.Current.GetInstance<IMappingValidator>();
-            var manager = ServiceLocator.Current.GetInstance<IReadOnlyMappingManager>();
-            Sitecore.Support.SolrServer<Dictionary<string, object>> server = new Sitecore.Support.SolrServer<Dictionary<string, object>>(operations, manager, validator);
-            objects.Add(typeKey, server);
+                var operations = ServiceLocator.Current.GetInstance<ISolrBasicOperations<Dictionary<string, object>>>(key);
+                var validator = ServiceLocator.Current.GetInstance<IMappingValidator>();
+                var manager = ServiceLocator.Current.GetInstance<IReadOnlyMappingManager>();
+                Sitecore.Support.SolrServer<Dictionary<string, object>> server = new Sitecore.Support.SolrServer<Dictionary<string, object>>(operations, manager, validator);
+                objects.Add(typeKey, server);
+            }
         }
 
     }


### PR DESCRIPTION
Original implementation would only correct issue when querying hardcoded index name.
This would also break if you changed the name of the sitecore_master_index or removed it on CD servers.  This implementation provides fix for all defined indexes.